### PR TITLE
Remove Remaining Parental Prefixes

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -54,16 +54,18 @@ TemplateRenderer.prototype.generateRandomID = () => `${randomDice++}`;
 const {Log, LogLevel, tag} = require("missionlog");
 
 const linkto = (...args) => linker.linkTo(...args);
+const removeParentalPrefix = (symbolPath) => symbolPath.replace(/.*[.#](.*)$/, "$1");
 const linkToDataType = (dataType) => {
   const out = linker.linkTo(dataType);
   // Remove the parental prefixes from the label within the <a> tag (eg. 'scene.', 'Container#', etc.)
   return out.replace(/<a href="([^"]+)">[^<]*(\.|#)([^.<#]+)<\/a>/g, "<a href=\"$1\">$3</a>");
 };
 const linkToSymbolPath = (symbolPath, path = symbolPath) => {
-  const extracted = path.replace(/.*[.#](.*)$/, "$1");
+  const extracted = removeParentalPrefix(path);
   // Remove the parental prefixes from the link text (eg. 'scene.', 'Container#', etc.).
   return linker.linkTo(symbolPath, extracted);
 };
+TemplateRenderer.prototype.removeParentalPrefix = removeParentalPrefix;
 TemplateRenderer.prototype.linkToDataType = linkToDataType;
 TemplateRenderer.prototype.linkToSymbolPath = linkToSymbolPath;
 

--- a/tmpl/doc/enum.tmpl
+++ b/tmpl/doc/enum.tmpl
@@ -2,7 +2,7 @@
 
 <div class="nameContainer">
     <h4 class="name" id="<?js= enumDoc.name ?>">
-        <?js= enumDoc.attribs + (enumDoc.path).replace(/.*[.#](.*)$/, "$1") + (enumDoc.signature ? enumDoc.signature : '') ?>
+        <?js= enumDoc.attribs + this.removeParentalPrefix(enumDoc.path) + (enumDoc.signature ? enumDoc.signature : '') ?>
     </h4>
 </div>
 

--- a/tmpl/members.tmpl
+++ b/tmpl/members.tmpl
@@ -15,7 +15,7 @@ if (doc.dataType) {
     <div class="nameContainer">
         <h4 class="name" id="<?js= doc.name ?>">
             <a class="share-icon" href="#<?js= doc.name ?>"><span class="glyphicon glyphicon-link"></span></a>
-            <span class="<?js= doc.deprecated ? 'status-deprecated' : '' ?>"><?js= (doc.scope === "static" ? doc.path : doc.name).replace(/.*[.#](.*)$/, "$1") ?></span>
+            <span class="<?js= doc.deprecated ? 'status-deprecated' : '' ?>"><?js= this.removeParentalPrefix(doc.scope === "static" ? doc.path : doc.name) ?></span>
             <?js= typeSignature ?>
             <?js if (doc.deprecated) { ?>
                 <span class="access-signature deprecated">Deprecated<?js

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -8,13 +8,10 @@ const kind = doc.type;
         <h4 class="name" id="<?js= doc.name ?>">
             <a class="share-icon" href="#<?js= doc.name ?>"><span class="glyphicon glyphicon-link"></span></a>
             <span class="<?js= doc.deprecated ? 'status-deprecated' : '' ?>">
-              <?js if (doc.name === "constructor" && doc.parent && doc.parent.type === "ClassDoc") {
-                const extracted = doc.parent.path.replace(/.*[.#](.*)$/, "$1"); ?>
-                  <?js= "new " + extracted ?>
-              <?js } else {
-                  const label = doc.scope === "static" && doc.type === "MethodDoc" ? doc.path : doc.name;
-                  const extracted = label.replace(/.*[.#](.*)$/, "$1"); ?>
-                  <?js=extracted?>
+              <?js if (doc.name === "constructor" && doc.parent && doc.parent.type === "ClassDoc") { ?>
+                  <?js= "new " + this.removeParentalPrefix(doc.parent.path) ?>
+              <?js } else { ?>
+                  <?js=this.removeParentalPrefix(doc.scope === "static" && doc.type === "MethodDoc" ? doc.path : doc.name)?>
               <?js } ?>
             </span>
             <?js= (doc.type !== 'EventDoc' ? doc.signature : '') ?>


### PR DESCRIPTION
Resolves [ticket](https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=46755676).
Preview: https://pixi-v8-parental-prefixes-removal-update.surge.sh

- Add missing parental prefix removal logic to the name tag on the member and enum templates.
- Override `TemplateTagsResolver`'s `runLinkTag` method to allow parental prefix removal on the {@link} tags on the docs.
- Add `removeParentalPrefix` method on the `TemplateRenderer` to streamline the parental prefix removal logic.